### PR TITLE
[Update]switch firstResponder changing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+xcshareddata/
 
 ## Other
 *.moved-aside

--- a/FormToolbar/FormToolbar.swift
+++ b/FormToolbar/FormToolbar.swift
@@ -235,16 +235,16 @@ final public class FormToolbar: UIToolbar {
     /// Go back to previous input.
     public func goBack() {
         if let currentFormItem = currentFormItem {
-            currentFormItem.input?.responder.resignFirstResponder()
             currentFormItem.previousInput?.responder.becomeFirstResponder()
+            currentFormItem.input?.responder.resignFirstResponder()
         }
     }
     
     /// Go forward to next input.
     public func goForward() {
         if let currentFormItem = currentFormItem {
-            currentFormItem.input?.responder.resignFirstResponder()
             currentFormItem.nextInput?.responder.becomeFirstResponder()
+            currentFormItem.input?.responder.resignFirstResponder()
         }
     }
     


### PR DESCRIPTION
When I use the FormToolbar, there is a bottom view which is following keyboard height over a scroll view.
When use goBack() or goForward(), that bottom view remake it's constraints. Then it move from top to keyboard. So It looks uncomfortable.

I switched the firstResponder changing. It works nice for me.

Thanks :)

